### PR TITLE
Add Services.Tests with self-reference check

### DIFF
--- a/Services.Tests/Services.Tests.csproj
+++ b/Services.Tests/Services.Tests.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="xunit" Version="2.5.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0" />
+    <PackageReference Include="Serilog" Version="3.0.1" />
+    <PackageReference Include="SlimMessageBus" Version="2.0.1" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Services\Services.csproj" />
+  </ItemGroup>
+</Project>

--- a/Services.Tests/TrainComponentRelations/Create/TrainComponentRelationsCreateRequestHandlerTests.cs
+++ b/Services.Tests/TrainComponentRelations/Create/TrainComponentRelationsCreateRequestHandlerTests.cs
@@ -1,0 +1,33 @@
+using System.Threading.Tasks;
+using Serilog;
+using Services.TrainComponentRelations.Create;
+using DAL.Abstract.TrainComponentRelations;
+using Domain;
+using Xunit;
+
+namespace Services.Tests.TrainComponentRelations.Create;
+
+public class TrainComponentRelationsCreateRequestHandlerTests
+{
+    [Fact]
+    public async Task Throws_when_component_references_itself()
+    {
+        var logger = new LoggerConfiguration().CreateLogger();
+        var repo = new StubRepo();
+        var handler = new TrainComponentRelationsCreateRequestHandler(logger, repo);
+        var request = new TrainComponentRelationsCreateRequest
+        {
+            TrainComponentId = 1,
+            TrainComponentParentId = 1,
+            TrainComponentContextId = 2
+        };
+
+        await Assert.ThrowsAsync<TrainComponentSelfReferenceException>(() => handler.OnHandle(request));
+    }
+
+    private class StubRepo : ITrainComponentRelationsRepository
+    {
+        public Task<int> Create(TrainComponentRelation entity) => Task.FromResult(0);
+        public Task<TrainComponentRelationItem[]> Get(int trainComponentContextId, int? parentComponentId) => Task.FromResult(System.Array.Empty<TrainComponentRelationItem>());
+    }
+}

--- a/tcm-api.sln
+++ b/tcm-api.sln
@@ -21,6 +21,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Web.API", "Web.API\Web.API.
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Services", "Services\Services.csproj", "{FBAFF1CF-55CB-4189-AF0C-69E77EB7F9F5}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Services.Tests", "Services.Tests\Services.Tests.csproj", "{2C56301E-3817-456B-873B-7B93FB5588ED}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -63,8 +65,12 @@ Global
 		{2ED44F12-DA51-4226-9B1D-08534C6B94BD}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{2ED44F12-DA51-4226-9B1D-08534C6B94BD}.Release|Any CPU.Build.0 = Release|Any CPU
 		{FBAFF1CF-55CB-4189-AF0C-69E77EB7F9F5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{FBAFF1CF-55CB-4189-AF0C-69E77EB7F9F5}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{FBAFF1CF-55CB-4189-AF0C-69E77EB7F9F5}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{FBAFF1CF-55CB-4189-AF0C-69E77EB7F9F5}.Release|Any CPU.Build.0 = Release|Any CPU
-	EndGlobalSection
+                {FBAFF1CF-55CB-4189-AF0C-69E77EB7F9F5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {FBAFF1CF-55CB-4189-AF0C-69E77EB7F9F5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {FBAFF1CF-55CB-4189-AF0C-69E77EB7F9F5}.Release|Any CPU.Build.0 = Release|Any CPU
+                {2C56301E-3817-456B-873B-7B93FB5588ED}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {2C56301E-3817-456B-873B-7B93FB5588ED}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {2C56301E-3817-456B-873B-7B93FB5588ED}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {2C56301E-3817-456B-873B-7B93FB5588ED}.Release|Any CPU.Build.0 = Release|Any CPU
+        EndGlobalSection
 EndGlobal


### PR DESCRIPTION
## Summary
- add `Services.Tests` project targeting net8.0
- test `TrainComponentRelationsCreateRequestHandler` self-reference logic
- include tests in `tcm-api.sln`

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688d04362f248329a4f4f8b53c128af0