### PR TITLE
Fix README code block closing

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,3 +45,10 @@ To start the API locally:
 
 ```bash
 docker-compose -f docker/development/docker-compose.yml up --build
+```
+
+Stop the services with `Ctrl+C` or by running:
+
+```bash
+docker-compose -f docker/development/docker-compose.yml down
+```


### PR DESCRIPTION
## Summary
- close the Docker command code block in README
- add info on how to stop services

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688d0427c2708329b35a71d22678e740