### PR TITLE
Update CanAssignQuantity to bool

### DIFF
--- a/DAL.Abstract/TrainComponentDto.cs
+++ b/DAL.Abstract/TrainComponentDto.cs
@@ -5,5 +5,5 @@ public class TrainComponentDto
     public int Id { get; init; }
     public string Name { get; init; }
     public string Number { get; init; }
-    public string CanAssignQuantity { get; init; }
+    public bool CanAssignQuantity { get; init; }
 }

--- a/DAL.EF/Repositories/TrainComponentRelationsRepository.cs
+++ b/DAL.EF/Repositories/TrainComponentRelationsRepository.cs
@@ -37,7 +37,8 @@ public class TrainComponentRelationsRepository : BaseRepository<TrainComponentRe
                 {
                     Id = joinedTrainComponent.Id,
                     Name = joinedTrainComponent.Name,
-                    Number = joinedTrainComponent.Number
+                    Number = joinedTrainComponent.Number,
+                    CanAssignQuantity = joinedTrainComponent.CanAssignQuantity
                 },
                 Quantity = tcr.Quantity
             }).ToArrayAsync();


### PR DESCRIPTION
## Summary
- change `CanAssignQuantity` type in `TrainComponentDto` from `string` to `bool`
- map `CanAssignQuantity` from entity when retrieving relations

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688d041b5e7c8329b9fc75b4c087af2d