### PR TITLE
Rename helper method in PropertyValueManager

### DIFF
--- a/Common/PropertyValueManager.cs
+++ b/Common/PropertyValueManager.cs
@@ -15,12 +15,12 @@ public class PropertyValueManager
         }
 
         PropertyInfoAndObj propertyInfoAndObj =
-            GetPropertyPropertyInfoAndObjForFinalProperty(source, fullPropertyName);
+            GetPropertyInfoAndObjForFinalProperty(source, fullPropertyName);
 
         return propertyInfoAndObj.PropertyInfo.GetValue(propertyInfoAndObj.OwnerOfProperty, null);
     }
 
-    private static PropertyInfoAndObj GetPropertyPropertyInfoAndObjForFinalProperty(object obj,
+    private static PropertyInfoAndObj GetPropertyInfoAndObjForFinalProperty(object obj,
         string fullPropertyName)
     {
         object referenceToOwnerOfProperty = GetReferenceToPropertyOwner(fullPropertyName, obj)!;


### PR DESCRIPTION
## Summary
- rename `GetPropertyPropertyInfoAndObjForFinalProperty` to `GetPropertyInfoAndObjForFinalProperty`
- update invocation of renamed method

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688d03edba2c8329ae94f29fb7104118